### PR TITLE
Add information about wingpanel-indicator-ayatana installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ The `wingpanel-indicator-ayatana` package is no longer included in the standard 
 To install the packages, you can use a .deb installer like [Eddy](http://appcenter.elementary.io/com.github.donadigo.eddy/) or run `sudo dpkg -i filename` in your terminal.
 Once you've installed both packages, a reboot should get your indicators working in Pantheon.
 
+Download and install .deb `wingpanel-indicator-ayatana` from [here](https://launchpad.net/~elementary-os/+archive/ubuntu/stable/+files/wingpanel-indicator-ayatana_2.0.3+r27+pkg17~ubuntu0.4.1.1_amd64.deb)
+
 ## Patching indicator-application
 ### Update the .desktop
 First, download the source to a directory of your choice by running `bzr branch lp:indicator-application` in your terminal (you'll need the `bzr` package installed if you don't already)
 
-The patch itself is very small and straightforward - edit the `indicator-application.desktop.in` file located in the data folder and edit it so this line:
+The patch itself is very small and straightforward - edit the `indicator-application.desktop.in` file located in the `data` folder and edit it so this line:
 
 `OnlyShowIn=Unity;GNOME;`
 
@@ -34,3 +36,16 @@ Now you can generate a patched .deb - the first step is to install the build dep
 in your terminal.
 
 The final step is to run `debuild -i -us -uc -b` in the root of the `indicator-application` folder. Once this has finished, there should be a .deb for you to install in the parent directory.
+
+
+### Adjust gap between icons
+Edit `/usr/share/themes/elementary/gtk-3.0/apps.css` or if you use https://github.com/surajmandalcell/elementary-x `/usr/share/themes/elementary-x/gtk-3.22/apps.css`, and set the padding of `.composited-indicator`:
+```
+.composited-indicator {
+    padding: 0 2px;
+}
+```
+
+Then set your theme to something else and then back again to make sure the changes are refreshed(or restart/log out)
+
+![](https://user-images.githubusercontent.com/2853554/44053369-227c10f2-9f48-11e8-8c79-6ed31cabb1f0.png)


### PR DESCRIPTION
Add information about wingpanel-indicator-ayatana installation [#2](https://github.com/mdh34/elementary-indicators/issues/2) and about gap between icons [#1](https://github.com/mdh34/elementary-indicators/issues/1)